### PR TITLE
Write block header protocol version to Database

### DIFF
--- a/src/server/db/MongoDB.ts
+++ b/src/server/db/MongoDB.ts
@@ -45,6 +45,7 @@ const blockSchema = new mongoose.Schema({
   blockHash: { type: String, index: { unique: true }},
   blockHeight: { type: (mongoose.Schema.Types as any).Long, index: { unique: true }},
   blockTimestamp: Number,
+  protocolVersion: Number,
   txIds: [String],
 });
 

--- a/src/server/transformers/blockTransform.ts
+++ b/src/server/transformers/blockTransform.ts
@@ -19,6 +19,7 @@ export function blockToBlockSummary(block: IBlock): IBlockSummary {
     blockHeight: block.blockHeight,
     numTransactions: block.txIds.length,
     blockTimestamp: block.blockTimestamp,
+    protocolVersion: block.protocolVersion,
   };
 }
 
@@ -30,6 +31,7 @@ export function blockResponseToBlockSummary(getBlockResponse: GetBlockResponse):
     blockHeight,
     numTransactions: getBlockResponse.transactions.length,
     blockTimestamp: getBlockResponse.blockTimestamp.getTime(),
+    protocolVersion: getBlockResponse.resultsBlockHeader.protocolVersion,
   };
 }
 
@@ -41,6 +43,7 @@ export function blockResponseToBlock(getBlockResponse: GetBlockResponse): IBlock
     blockHash,
     blockTimestamp: getBlockResponse.blockTimestamp.getTime(),
     txIds: getBlockResponse.transactions.map(tx => encodeHex(tx.txId)),
+    protocolVersion: getBlockResponse.resultsBlockHeader.protocolVersion,
   };
 }
 

--- a/src/shared/IBlock.d.ts
+++ b/src/shared/IBlock.d.ts
@@ -10,6 +10,7 @@ interface IBlockHeader {
   blockHash: string;
   blockHeight: string;
   blockTimestamp: number;
+  protocolVersion: number;
 }
 
 export interface IBlockSummary extends IBlockHeader {


### PR DESCRIPTION
Extracts protocol version (from results block header) and write it in blocks collection. this assumes that protocol version is always identical in results and transactions block headers. Meant to assist in checking protocol version upgrades.

this PR does not handle presenting the protocol version in the UI